### PR TITLE
Add HTTP server transport with port option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ COPY --from=builder /app/package.json ./
 
 ARG VERSION
 ENV APP_VERSION=$VERSION
+EXPOSE 3000
 
 CMD ["node", "build/index.js"]

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,7 +42,7 @@ Backlog API とやり取りするための Model Context Protocol（MCP）サー
       "args": [
         "run",
         "--pull", "always",
-        "-i",
+        "-p", "3000:3000",
         "--rm",
         "-e", "BACKLOG_DOMAIN",
         "-e", "BACKLOG_API_KEY",
@@ -216,7 +216,7 @@ PROJECT-KEYプロジェクトの「repo-name」リポジトリで、ブランチ
       "command": "docker",
       "args": [
         "run",
-        "-i",
+        "-p", "3000:3000",
         "--rm",
         "-e", "BACKLOG_DOMAIN",
         "-e", "BACKLOG_API_KEY",
@@ -241,7 +241,7 @@ PROJECT-KEYプロジェクトの「repo-name」リポジトリで、ブランチ
 例：
 
 ```bash
-docker run -i --rm ghcr.io/nulab/backlog-mcp-server node build/index.js --export-translations
+docker run --rm -p 3000:3000 ghcr.io/nulab/backlog-mcp-server node build/index.js --export-translations
 ```
 
 または
@@ -276,7 +276,7 @@ translationConfig/.backlog-mcp-serverrc.json.example
       "command": "docker",
       "args": [
         "run",
-        "-i",
+        "-p", "3000:3000",
         "--rm",
         "-e", "BACKLOG_DOMAIN",
         "-e", "BACKLOG_API_KEY",
@@ -373,7 +373,7 @@ MAX_TOKENS=10000
       "command": "docker",
       "args": [
         "run",
-        "-i",
+        "-p", "3000:3000",
         "--rm",
         "-e", "BACKLOG_DOMAIN",
         "-e", "BACKLOG_API_KEY",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The easiest way to use this MCP server is through MCP configurations:
       "args": [
         "run",
         "--pull", "always",
-        "-i",
+        "-p", "3000:3000",
         "--rm",
         "-e", "BACKLOG_DOMAIN",
         "-e", "BACKLOG_API_KEY",
@@ -272,7 +272,7 @@ Sample config:
       "command": "docker",
       "args": [
         "run",
-        "-i",
+        "-p", "3000:3000",
         "--rm",
         "-e", "BACKLOG_DOMAIN",
         "-e", "BACKLOG_API_KEY",
@@ -297,7 +297,7 @@ This will print all tool descriptions to stdout, including any customizations yo
 Example:
 
 ```bash
-docker run -i --rm ghcr.io/nulab/backlog-mcp-server node build/index.js --export-translations
+docker run --rm -p 3000:3000 ghcr.io/nulab/backlog-mcp-server node build/index.js --export-translations
 ```
 
 or 
@@ -332,7 +332,7 @@ To override the TOOL_ADD_ISSUE_COMMENT_DESCRIPTION:
       "command": "docker",
       "args": [
         "run",
-        "-i",
+        "-p", "3000:3000",
         "--rm",
         "-e", "BACKLOG_DOMAIN",
         "-e", "BACKLOG_API_KEY",
@@ -429,7 +429,7 @@ This section demonstrates advanced configuration using multiple environment vari
       "command": "docker",
       "args": [
         "run",
-        "-i",
+        "-p", "3000:3000",
         "--rm",
         "-e", "BACKLOG_DOMAIN",
         "-e", "BACKLOG_API_KEY",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHttpServerTransport } from "@modelcontextprotocol/sdk/server/http.js";
 import * as backlogjs from 'backlog-js';
 import dotenv from "dotenv";
 import { default as env } from 'env-var';
@@ -50,6 +50,11 @@ const argv = yargs(hideBin(process.argv))
     describe: "Export translations and exit",
     default: false,
   })
+  .option("port", {
+    type: "number",
+    describe: "Port to listen on",
+    default: env.get("PORT").default("3000").asPortNumber(),
+  })
   .option("enable-toolsets", {
     type: "array",
     describe: `Specify which toolsets to enable. Defaults to 'all'.
@@ -82,6 +87,7 @@ const transHelper = createTranslationHelper()
 
 const maxTokens = argv.maxTokens;
 const prefix = argv.prefix;
+const port = argv.port;
 let enabledToolsets = argv.enableToolsets as string[];
 
 // If dynamic toolsets are enabled, remove "all" to allow for selective enabling via commands
@@ -111,9 +117,9 @@ if (argv.exportTranslations) {
 }
 
 async function main() {
-  const transport = new StdioServerTransport();
+  const transport = new StreamableHttpServerTransport({ port });
   await server.connect(transport);
-  console.error("Backlog MCP Server running on stdio");
+  console.error(`Backlog MCP Server running on http://0.0.0.0:${port}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- use `StreamableHttpServerTransport` instead of stdio
- expose port configuration with new `--port` CLI flag and `PORT` env var
- update Dockerfile to expose the default port
- document container usage with `-p` instead of `-i`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841308269188333a0ae0950fae3789c